### PR TITLE
Set up better registry management and configuration

### DIFF
--- a/res/default_config.yaml
+++ b/res/default_config.yaml
@@ -2,6 +2,12 @@ apiVersion: mistletoe.dev/v1alpha1
 kind: MistletoeConfig
 spec:
   registries:
-    mistletoe:
-      type: Git
-      git: https://github.com/gsfraley/mistletoe-registry.git
+  - name: mistletoe
+    defaultRemote: github-https
+    remotes:
+    - name: github-https
+      git:
+        url: https://github.com/gsfraley/mistletoe-registry.git
+    - name: github-ssh
+      git:
+        url: git@github.com:gsfraley/mistletoe-registry.git

--- a/src/bin/mistctl.rs
+++ b/src/bin/mistctl.rs
@@ -44,6 +44,12 @@ async fn main() {
                     Command::new("list")
                         .about("Lists the configured registries")
                 )
+                .subcommand(
+                    Command::new("remove")
+                        .about("Removes the given registry")
+                        .arg(arg!([name] "the name of the registry to remove")
+                            .required(true))
+                )
         )
         .get_matches();
 
@@ -69,6 +75,10 @@ async fn run_cli(matches: &ArgMatches) -> anyhow::Result<()> {
     if let Some(matches) = matches.subcommand_matches("registry") {
         if let Some(matches) = matches.subcommand_matches("list") {
             registry_list::run_command(&matches)?;
+        }
+
+        if let Some(matches) = matches.subcommand_matches("remove") {
+            registry_remove::run_command(&matches)?;
         }
     }
 

--- a/src/bin/mistctl.rs
+++ b/src/bin/mistctl.rs
@@ -37,6 +37,14 @@ async fn main() {
                 .about("Inspects the info exported by a package")
                 .arg(arg!([package] "the package to inspect"))
         )
+        .subcommand(
+            Command::new("registry")
+                .about("Manage the configured registries for Mistletoe")
+                .subcommand(
+                    Command::new("list")
+                        .about("Lists the configured registries")
+                )
+        )
         .get_matches();
 
     if let Err(e) = run_cli(&matches).await {
@@ -56,6 +64,12 @@ async fn run_cli(matches: &ArgMatches) -> anyhow::Result<()> {
 
     if let Some(matches) = matches.subcommand_matches("inspect") {
         inspect::run_command(&matches)?;
+    }
+
+    if let Some(matches) = matches.subcommand_matches("registry") {
+        if let Some(matches) = matches.subcommand_matches("list") {
+            registry_list::run_command(&matches)?;
+        }
     }
 
     Ok(())

--- a/src/bin/mistctl.rs
+++ b/src/bin/mistctl.rs
@@ -41,6 +41,13 @@ async fn main() {
             Command::new("registry")
                 .about("Manage the configured registries for Mistletoe")
                 .subcommand(
+                    Command::new("add")
+                        .about("Adds a new registry")
+                        .arg(arg!([name] "the name to give the registry")
+                            .required(true))
+                        .arg(arg!(-g --git <URL> "a git remote url"))
+                )
+                .subcommand(
                     Command::new("list")
                         .about("Lists the configured registries")
                 )
@@ -73,6 +80,10 @@ async fn run_cli(matches: &ArgMatches) -> anyhow::Result<()> {
     }
 
     if let Some(matches) = matches.subcommand_matches("registry") {
+        if let Some(matches) = matches.subcommand_matches("add") {
+            registry_add::run_command(matches)?;
+        }
+
         if let Some(matches) = matches.subcommand_matches("list") {
             registry_list::run_command(&matches)?;
         }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,5 +1,6 @@
 pub mod generate;
 pub mod inspect;
 pub mod install;
+pub mod registry_add;
 pub mod registry_list;
 pub mod registry_remove;

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,3 +1,4 @@
 pub mod generate;
 pub mod inspect;
 pub mod install;
+pub mod registry_list;

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -2,3 +2,4 @@ pub mod generate;
 pub mod inspect;
 pub mod install;
 pub mod registry_list;
+pub mod registry_remove;

--- a/src/command/registry_add.rs
+++ b/src/command/registry_add.rs
@@ -1,0 +1,25 @@
+use clap::ArgMatches;
+
+use crate::config::{ConfigLayout, RegistryLayout, RemoteLayout, GitRemoteLayout};
+
+pub fn run_command(matches: &ArgMatches) -> anyhow::Result<()> {
+    let name = matches.get_one::<String>("name").unwrap();
+    let git = matches.get_one::<String>("git").unwrap();
+    let mut config = ConfigLayout::from_env()?;
+
+    let registry_layout = RegistryLayout {
+        name: name.to_string(),
+        default_remote: "default".to_string(),
+        remotes: vec![RemoteLayout::Git {
+            name: "default".to_string(),
+            git: GitRemoteLayout {
+                url: git.to_string(),
+            },
+        }],
+    };
+
+    config.spec.registries.push(registry_layout);
+    config.write_to_env()?;
+
+    Ok(())
+}

--- a/src/command/registry_list.rs
+++ b/src/command/registry_list.rs
@@ -1,0 +1,8 @@
+use crate::config::ConfigLayout;
+
+use clap::ArgMatches;
+
+pub fn run_command(_: &ArgMatches) -> anyhow::Result<()> {
+    println!("{}", serde_yaml::to_string(&ConfigLayout::from_env()?.spec.registries)?);
+    Ok(())
+}

--- a/src/command/registry_remove.rs
+++ b/src/command/registry_remove.rs
@@ -1,0 +1,21 @@
+use crate::config::{ConfigLayout, RegistryLayout};
+
+use anyhow::anyhow;
+use clap::ArgMatches;
+
+pub fn run_command(matches: &ArgMatches) -> anyhow::Result<()> {
+    let name = matches.get_one::<String>("name").unwrap();
+    let mut config = ConfigLayout::from_env()?;
+
+    let registry = config.spec.lookup_registry(name)
+        .ok_or(anyhow!("could not find registry with the name \"{}\"", name))?;
+
+    config.spec.registries = config.spec.registries.iter()
+        .filter(|r| r.name != registry.name)
+        .map(RegistryLayout::clone)
+        .collect();
+
+    config.write_to_env()?;
+
+    Ok(())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,7 +51,7 @@ impl ConfigLayout {
         Self::from_str(&std::fs::read_to_string(path)?)
     }
 
-    pub fn from_env() -> anyhow::Result<Self> {
+    fn create_env() -> anyhow::Result<()> {
         if !MIST_HOME_LOCATION.is_dir() {
             std::fs::create_dir(&*MIST_HOME_LOCATION)?;
 
@@ -75,7 +75,23 @@ impl ConfigLayout {
             std::fs::write(&*MIST_CONFIG_LOCATION, MIST_CONFIG_DEFAULT_CONTENTS)?;
         }
 
+        Ok(())
+    }
+
+    pub fn from_env() -> anyhow::Result<Self> {
+        Self::create_env()?;
         Self::from_file(&*MIST_CONFIG_LOCATION)
+    }
+
+    pub fn write_to_file(&self, path: &Path) -> anyhow::Result<()> {
+        std::fs::write(path, serde_yaml::to_string(self)?)?;
+        Ok(())
+    }
+
+    pub fn write_to_env(&self) -> anyhow::Result<()> {
+        Self::create_env()?;
+        self.write_to_file(&*MIST_CONFIG_LOCATION)?;
+        Ok(())
     }
 }
 
@@ -98,7 +114,7 @@ impl SpecLayout {
     }
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RegistryLayout {
     pub name: String,
@@ -128,7 +144,7 @@ impl RegistryLayout {
     }
 }
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum RemoteLayout {
     Git {
@@ -145,7 +161,7 @@ impl RemoteLayout {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct GitRemoteLayout {
     pub url: String,
 }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1,5 +1,5 @@
-use crate::config::MistletoeConfig;
-use crate::registry::Registry;
+use crate::config::ConfigLayout;
+use crate::registry::Remote;
 
 use std::path::{Path, PathBuf};
 
@@ -79,21 +79,14 @@ impl MistPackageInstance {
                 Ok(MistPackageInstance::init(true, store, module)?)
             },
             MistPackageRef::Remote { registry, package, version } => {
-                let registry_instance = Registry::from_name(
+                let remote = Remote::default_for_name(
                     registry,
-                    &MistletoeConfig::from_env()?);
+                    &ConfigLayout::from_env()?)?;
 
-                if registry_instance.is_none() {
-                    return Err(anyhow!(
-                        "could not find a registry saved with the name {}",
-                        registry));
-                }
+                remote.init()?;
+                remote.pull()?;
 
-                let registry_instance = registry_instance.unwrap();
-                registry_instance.init()?;
-                registry_instance.pull()?;
-
-                let package_path = registry_instance
+                let package_path = remote
                     .lookup_package(&PathBuf::from(package), version)
                     .ok_or_else(|| anyhow!("could not find package at {}", package))?;
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,42 +1,78 @@
-use crate::config::{MIST_HOME_LOCATION, MistletoeConfig};
+use crate::config::{MIST_HOME_LOCATION, RemoteLayout, ConfigLayout};
 
 use std::path::{Path, PathBuf};
 
+use anyhow::anyhow;
 use git2::Repository;
 
-pub struct Registry {
-    name: String,
-    git: String,
+pub struct Remote {
+    layout: RemoteLayout,
 }
 
-impl Registry {
-    pub fn from_name(name: &str, config: &MistletoeConfig) -> Option<Self> {
-        config.spec.registries.get(name).map(|r| Registry {
-            name: name.to_string(),
-            git: r.git.clone()
-        })
+impl From<RemoteLayout> for Remote {
+    fn from(layout: RemoteLayout) -> Self {
+        Self { layout }
+    }
+}
+
+impl Remote {
+    pub fn default_for_name(name: &str, config: &ConfigLayout) -> anyhow::Result<Self> {
+        let registry = config.spec.lookup_registry(name)
+            .ok_or(anyhow!("could not find registry for name \"{}\"", name))?;
+        let remote = registry.lookup_default_remote()
+            .ok_or(anyhow!("registry \"{}\" did not have a remote by the default name \"{}\"", name, registry.default_remote))?;
+
+        Ok(remote.clone().into())
     }
 
+    pub fn init(&self) -> anyhow::Result<()> {
+        match &self.layout {
+            RemoteLayout::Git { name, git }
+                => GitRemote { name: name.to_string(), url: git.url.clone() }.init(),
+        }
+    }
+
+    pub fn pull(&self) -> anyhow::Result<()> {
+        match &self.layout {
+            RemoteLayout::Git { name, git }
+                => GitRemote { name: name.to_string(), url: git.url.clone() }.pull(),
+        }
+    }
+
+    pub fn lookup_package(&self, package: &Path, version: &str) -> Option<PathBuf> {
+        match &self.layout {
+            RemoteLayout::Git { name, git }
+                => GitRemote { name: name.to_string(), url: git.url.clone() }.lookup_package(package, version),
+        }
+    }
+}
+
+struct GitRemote {
+    name: String,
+    url: String,
+}
+
+impl GitRemote {
     fn get_local_registry_path(&self) -> PathBuf {
         MIST_HOME_LOCATION
             .join(Path::new("registries"))
             .join(Path::new(&self.name))
     }
-
-    pub fn init(&self) -> anyhow::Result<()> {
+    
+    fn init(&self) -> anyhow::Result<()> {
         let initted = self.get_local_registry_path()
             .join(Path::new(".git"))
             .exists();
 
         if !initted {
             std::fs::create_dir_all(self.get_local_registry_path())?;
-            Repository::clone(&self.git, self.get_local_registry_path())?;
+            Repository::clone(&self.url, self.get_local_registry_path())?;
         }
 
         Ok(())
     }
 
-    pub fn pull(&self) -> anyhow::Result<()> {
+    fn pull(&self) -> anyhow::Result<()> {
         let repository = Repository::open(self.get_local_registry_path())?;
         let head = repository.head()?.shorthand().unwrap().to_string();
 
@@ -52,7 +88,7 @@ impl Registry {
         Ok(())
     }
 
-    pub fn lookup_package(&self, package: &Path, version: &str) -> Option<PathBuf> {
+    fn lookup_package(&self, package: &Path, version: &str) -> Option<PathBuf> {
         let package_path = self.get_local_registry_path()
             .join(&package)
             .join(format!("{}-{}.mist-pack.wasm",


### PR DESCRIPTION
The current registry logic is sorta slapped together.  Not that it can be perfected due to the rough nature of it, but even a little clean-up will go a long way.  More importantly, we'll need registry management from the CLI, so some `add`, `remove`, `list` commands should be part of this PR, too.